### PR TITLE
Migrate away from gnome-common deprecated vars and macros

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,15 +1,40 @@
-#!/bin/bash
+#!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="cinnamon-menus"
-REQUIRED_AUTOMAKE_VERSION=1.10
+cd $srcdir
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from GNOME Subversion (or from"
-    echo "your distribution's package manager)."
+(test -f configure.ac) || {
+    echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
     exit 1
 }
-USE_GNOME2_MACROS=1 USE_COMMON_DOC_BUILD=yes . gnome-autogen.sh
+
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
+
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+    echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+    echo "*** If you wish to pass any to it, please specify them on the" >&2
+    echo "*** '$0' command line." >&2
+    echo "" >&2
+fi
+
+aclocal --install || exit 1
+glib-gettextize --force --copy || exit 1
+gtkdocize --copy || exit 1
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+    $srcdir/configure "$@" || exit 1
+
+    if [ "$1" = "--help" ]; then exit 0 else
+        echo "Now type 'make' to compile $PKG_NAME" || exit 1
+    fi
+else
+    echo "Skipping configure process."
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -2,14 +2,15 @@ AC_PREREQ(2.62)
 
 AC_INIT([cinnamon-menus], [3.0.2])
 AC_CONFIG_SRCDIR(libmenu/gmenu-tree.h)
+AX_IS_RELEASE([git-directory])
 
 AM_INIT_AUTOMAKE([1.11 foreign no-dist-gzip dist-xz])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_MACRO_DIR([m4])
+AC_SUBST([ACLOCAL_AMFLAGS], ["-I $ac_macro_dir \${ACLOCAL_FLAGS}"])
 AC_CONFIG_HEADERS(config.h)
 
 AM_MAINTAINER_MODE
-GNOME_MAINTAINER_MODE_DEFINES
 
 # Before making a release, the LT_VERSION string should be modified.
 # The string is of the form C:R:A.
@@ -32,7 +33,7 @@ PKG_CHECK_MODULES(GIO_UNIX, gio-unix-2.0 >= 2.29.15)
 AC_SUBST(GIO_UNIX_CFLAGS)
 AC_SUBST(GIO_UNIX_LIBS)
 
-GNOME_COMPILE_WARNINGS(yes)
+AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])
 
 AC_ARG_ENABLE(deprecation_flags,
               [AC_HELP_STRING([--enable-deprecation-flags],

--- a/libmenu/Makefile.am
+++ b/libmenu/Makefile.am
@@ -2,6 +2,7 @@ lib_LTLIBRARIES = libcinnamon-menu-3.la
 
 AM_CPPFLAGS =				\
 	$(GIO_UNIX_CFLAGS)		\
+	$(WARN_CFLAGS)			\
 	-DGMENU_I_KNOW_THIS_IS_UNSTABLE	\
 	$(DISABLE_DEPRECATED_CFLAGS)	\
 	$(DEBUG_CFLAGS)
@@ -35,6 +36,7 @@ libcinnamon_menu_3_la_LIBADD = 		\
 	$(GIO_UNIX_LIBS)
 
 libcinnamon_menu_3_la_LDFLAGS =			\
+	$(WARN_LDFLAGS)				\
 	-version-info $(LIB_MENU_LT_VERSION)	\
 	-no-undefined				\
 	-export-symbols-regex gmenu_tree
@@ -61,7 +63,7 @@ CMenu-3.0.gir: libcinnamon-menu-3.la
 CMenu_3_0_gir_INCLUDES = Gio-2.0
 CMenu_3_0_gir_CFLAGS = $(AM_CPPFLAGS)
 CMenu_3_0_gir_LIBS = libcinnamon-menu-3.la
-CMenu_3_0_gir_SCANNERFLAGS = --identifier-prefix=GMenu --symbol-prefix=gmenu --pkg-export=libcinnamon-menu-3.0 --c-include=gmenu-tree.h
+CMenu_3_0_gir_SCANNERFLAGS = $(WARN_SCANNERFLAGS) --identifier-prefix=GMenu --symbol-prefix=gmenu --pkg-export=libcinnamon-menu-3.0 --c-include=gmenu-tree.h
 CMenu_3_0_gir_FILES = $(addprefix $(srcdir)/,$(introspection_sources))
 INTROSPECTION_GIRS += CMenu-3.0.gir
 


### PR DESCRIPTION
gnome-common is deprecating some vars and macros, listed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829932

This change follows the gnome recommendations from:
https://wiki.gnome.org/Projects/GnomeCommon/Migration