### PR TITLE
Build: fix the build options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,20 @@ c_args = [
     '-DGMENU_I_KNOW_THIS_IS_UNSTABLE',
 ]
 
+if get_option('enable_debug')
+    c_args += '-DG_ENABLE_DEBUG'
+else
+    c_args += '-DG_DISABLE_ASSERT'
+    c_args += '-DG_DISABLE_CHECKS'
+    c_args += '-DG_DISABLE_CAST_CHECKS'
+endif
+
+if not get_option('deprecated_warnings')
+    c_args += '-Wno-deprecated-declarations'
+    c_args += '-Wno-deprecated'
+    c_args += '-Wno-declaration-after-statement'
+endif
+
 add_global_arguments(c_args, language: 'c')
 
 gio = dependency('gio-unix-2.0', version: '>= 2.29.15')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,10 +1,10 @@
 option('deprecated_warnings',
 	type: 'boolean',
-	value: false,
+	value: true,
 	description: 'Show build warnings for deprecations'
 )
-option('debug',
+option('enable_debug',
 	type: 'boolean',
-	value: false,
+	value: true,
 	description: 'Enable debugging'
 )


### PR DESCRIPTION
This fixes an issue on newer versions of meson where 'debug' is a reserved word, which causes the build to fail. It also implements the options in meson.build where they were supposed to pass flags to the compiler but did not until now.