### PR TITLE
meson: add option to control building the API docs

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,8 @@ override_dh_auto_configure:
 		--prefix=/usr \
 		--buildtype=plain \
 		-D deprecated_warnings=false \
-		-D enable_debug=false
+		-D enable_debug=false \
+		-D docs=true
 
 override_dh_auto_clean:
 	-dh_auto_clean

--- a/meson.build
+++ b/meson.build
@@ -55,4 +55,6 @@ add_global_arguments(c_args, language: 'c')
 gio = dependency('gio-unix-2.0', version: '>= 2.29.15')
 
 subdir('libmenu')
-subdir('docs/reference')
+if get_option('docs')
+    subdir('docs/reference')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,8 @@ option('enable_debug',
 	value: true,
 	description: 'Enable debugging'
 )
+ option('docs',
+    type: 'boolean',
+    value: false,
+    description: 'Build the API references (requires gtk-doc)'
+)


### PR DESCRIPTION
I might not want the docs, and if so, I don't want to need gtk-doc installed.