### PR TITLE
Fix loading of desktop files in subdirectories

### DIFF
--- a/libmenu/desktop-entries.c
+++ b/libmenu/desktop-entries.c
@@ -767,7 +767,6 @@ desktop_entry_set_add_entry (DesktopEntrySet *set,
                              DesktopEntry    *entry,
                              const char      *file_id)
 {
-  const char *file_id_to_use;
   menu_verbose (" Adding to set %p entry %s\n", set, file_id);
 
   if (set->hash == NULL)
@@ -778,14 +777,8 @@ desktop_entry_set_add_entry (DesktopEntrySet *set,
                                          (GDestroyNotify) desktop_entry_unref);
     }
 
-  if (desktop_entry_get_type (entry) == DESKTOP_ENTRY_DESKTOP) {
-    file_id_to_use = desktop_entry_get_id (entry);
-  }
-  else {
-    file_id_to_use = file_id;
-  }
   g_hash_table_replace (set->hash,
-                        g_strdup (file_id_to_use),
+                        g_strdup (file_id),
                         desktop_entry_ref (entry));
 }
 

--- a/libmenu/entry-directories.c
+++ b/libmenu/entry-directories.c
@@ -923,7 +923,8 @@ entry_directory_get_directory (EntryDirectory *ed,
 static char *
 get_desktop_file_id_from_path (EntryDirectory   *ed,
 			       DesktopEntryType  entry_type,
-			       const char       *relative_path)
+			       const char       *relative_path,
+             DesktopEntry *entry)
 {
   char *retval;
 
@@ -931,7 +932,16 @@ get_desktop_file_id_from_path (EntryDirectory   *ed,
 
   if (entry_type == DESKTOP_ENTRY_DESKTOP)
     {
+      GMenuDesktopAppInfo *appinfo;
+      appinfo = desktop_entry_get_app_info (entry);
       retval = g_strdelimit (g_strdup (relative_path), "/", '-');
+      if (gmenu_desktopappinfo_get_is_flatpak (appinfo))
+      {
+        char* tmp;
+        tmp = retval;
+        retval = g_strconcat (retval, GMENU_DESKTOPAPPINFO_FLATPAK_SUFFIX, NULL);
+        g_free (tmp);
+      }
     }
   else
     {
@@ -978,7 +988,8 @@ entry_directory_foreach_recursive (EntryDirectory            *ed,
 
 	  file_id = get_desktop_file_id_from_path (ed,
 						   ed->entry_type,
-						   relative_path->str);
+						   relative_path->str,
+               entry);
 
           ret = func (ed, entry, file_id, set, user_data);
 


### PR DESCRIPTION
This fixes loading of files in directories like '/usr/share/applications/kde4'
in cases where the same desktop file appears in the non-sub directory specified in the menu layout